### PR TITLE
Update CladeTime tree_as_of and sequence_as_of date handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 tmp_path_retention_policy = "none"
 filterwarnings = [
+    "ignore::cladetime.exceptions.CladeTimeFutureDateWarning",
     "ignore::DeprecationWarning",
     'ignore:polars found a filename',
 ]

--- a/src/cladetime/cladetime.py
+++ b/src/cladetime/cladetime.py
@@ -86,8 +86,6 @@ class CladeTime:
     @sequence_as_of.setter
     def sequence_as_of(self, date) -> None:
         """Set the sequence_as_of attribute."""
-        if date is None:
-            sequence_as_of = datetime.now()
         sequence_as_of = self._validate_as_of_date(date)
         utc_now = datetime.now().replace(tzinfo=timezone.utc)
         if sequence_as_of > utc_now:

--- a/src/cladetime/cladetime.py
+++ b/src/cladetime/cladetime.py
@@ -1,11 +1,12 @@
 """Class for clade time traveling."""
 
+import warnings
 from datetime import datetime, timezone
 
 import polars as pl
 import structlog
 
-from cladetime.exceptions import CladeTimeInvalidDateError, CladeTimeInvalidURLError
+from cladetime.exceptions import CladeTimeFutureDateWarning, CladeTimeInvalidDateError, CladeTimeInvalidURLError
 from cladetime.util.config import Config
 from cladetime.util.reference import _get_s3_object_url
 from cladetime.util.sequence import _get_ncov_metadata, get_covid_genome_metadata
@@ -54,12 +55,12 @@ class CladeTime:
         tree_as_of : datetime | str | None, default = now()
             Use the NextStrain reference tree that was available as of this date.
             Can be a datetime object, a string in the format
-            "YYYY-MM-DD", or None (which defaults to the current date and time).
+            "YYYY-MM-DD", or None (which defaults to the sequence_as_of date).
         """
 
         self._config = self._get_config()
-        self.sequence_as_of = self._validate_as_of_date(sequence_as_of)
-        self.tree_as_of = self._validate_as_of_date(tree_as_of)
+        self.sequence_as_of = sequence_as_of
+        self.tree_as_of = tree_as_of
         self._ncov_metadata = {}
         self._sequence_metadata = pl.LazyFrame()
 
@@ -79,12 +80,53 @@ class CladeTime:
             self.url_ncov_metadata = None
 
     @property
+    def sequence_as_of(self) -> datetime:
+        return self._sequence_as_of
+
+    @sequence_as_of.setter
+    def sequence_as_of(self, date) -> None:
+        """Set the sequence_as_of attribute."""
+        if date is None:
+            sequence_as_of = datetime.now()
+        sequence_as_of = self._validate_as_of_date(date)
+        utc_now = datetime.now().replace(tzinfo=timezone.utc)
+        if sequence_as_of > utc_now:
+            warnings.warn(
+                f"specified sequence_as_of is in the future, defaulting to current time: {utc_now}",
+                category=CladeTimeFutureDateWarning,
+            )
+            sequence_as_of = utc_now
+
+        self._sequence_as_of = sequence_as_of
+
+    @property
+    def tree_as_of(self) -> datetime:
+        return self._tree_as_of
+
+    @tree_as_of.setter
+    def tree_as_of(self, date) -> None:
+        """Set the tree_as_of attribute."""
+        if date is None:
+            tree_as_of = self.sequence_as_of
+        else:
+            tree_as_of = self._validate_as_of_date(date)
+        utc_now = datetime.now().replace(tzinfo=timezone.utc)
+        if tree_as_of > utc_now:
+            warnings.warn(
+                f"specified tree_as_of is in the future, defaulting to sequence_as_of: {self.sequence_as_of}",
+                category=CladeTimeFutureDateWarning,
+            )
+            tree_as_of = self.sequence_as_of
+
+        self._tree_as_of = tree_as_of
+
+    @property
     def ncov_metadata(self):
         return self._ncov_metadata
 
     @ncov_metadata.getter
     def ncov_metadata(self) -> dict:
-        """Set the ncov_metadata attribute."""
+        """Get the ncov_metadata attribute."""
         if self.url_ncov_metadata:
             metadata = _get_ncov_metadata(self.url_ncov_metadata)
             return metadata
@@ -98,13 +140,12 @@ class CladeTime:
 
     @sequence_metadata.getter
     def sequence_metadata(self) -> pl.LazyFrame:
-        """Set the sequence_metadata attribute."""
+        """Get the sequence_metadata attribute."""
         if self.url_sequence_metadata:
             sequence_metadata = get_covid_genome_metadata(metadata_url=self.url_sequence_metadata)
             return sequence_metadata
         else:
             raise CladeTimeInvalidURLError("CladeTime is missing url_sequence_metadata")
-        return sequence_metadata
 
     def __repr__(self):
         return f"CladeTime(sequence_as_of={self.sequence_as_of}, tree_as_of={self.tree_as_of})"
@@ -121,7 +162,7 @@ class CladeTime:
         return config
 
     def _validate_as_of_date(self, as_of: str) -> datetime:
-        """Validate date the as_of dates used to instantiate CladeTime."""
+        """Validate an as_of date (UTC) used to instantiate CladeTime."""
         if as_of is None:
             as_of_date = datetime.now()
         elif isinstance(as_of, datetime):
@@ -135,8 +176,5 @@ class CladeTime:
         as_of_date = as_of_date.replace(microsecond=0, tzinfo=timezone.utc)
         if as_of_date < self._config.nextstrain_min_seq_date:
             raise CladeTimeInvalidDateError(f"Date must be after May 1, 2023: {as_of_date}")
-
-        if as_of_date > datetime.now().replace(tzinfo=timezone.utc):
-            raise CladeTimeInvalidDateError(f"Date cannot be in the future: {as_of_date}")
 
         return as_of_date

--- a/src/cladetime/exceptions.py
+++ b/src/cladetime/exceptions.py
@@ -11,3 +11,7 @@ class CladeTimeInvalidDateError(Error):
 
 class CladeTimeInvalidURLError(Error):
     """Raised when CladeTime encounters an invalid URL."""
+
+
+class CladeTimeFutureDateWarning(Warning):
+    """Raised when CladeTime as_of date is in the future."""


### PR DESCRIPTION
Resolve #33 

See the linked issue for details. Essentially, this PR modifies two cases when setting `sequence_as_of` and `tree_as_of` dates for `CladeTime` objects:

* if no tree_as_of parameter is specified when instantiating CladeTime, tree_as_of should default to the sequence_as_of value.

* if either tree_as_of or sequence_as_of is a future date, CladeTime instantiation should give a warning and use the current datetime value instead.