### PR TITLE
Bsweger/filter fasta/48

### DIFF
--- a/docs/reference/sequence.rst
+++ b/docs/reference/sequence.rst
@@ -3,3 +3,7 @@ Sequence
 =========
 
 .. autofunction:: cladetime.sequence.filter_sequence_metadata
+
+.. autofunction:: cladetime.sequence.get_sequence_set
+
+.. autofunction:: cladetime.sequence.filter_sequence_data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 
 dependencies = [
     "awscli>=1.32.92",
+    "biopython",
     "boto3",
     "click",
     "cloudpathlib",

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -2,6 +2,8 @@
 #    uv pip compile pyproject.toml --extra dev -o requirements/requirements-dev.txt
 awscli==1.32.116
     # via cladetime (pyproject.toml)
+biopython==1.84
+    # via cladetime (pyproject.toml)
 boto3==1.34.116
     # via
     #   cladetime (pyproject.toml)
@@ -70,6 +72,7 @@ mypy-extensions==1.0.0
     # via mypy
 numpy==1.26.4
     # via
+    #   biopython
     #   pandas
     #   pyarrow
 packaging==24.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,8 @@
 #    uv pip compile pyproject.toml -o requirements/requirements.txt
 awscli==1.32.97
     # via cladetime (pyproject.toml)
+biopython==1.84
+    # via cladetime (pyproject.toml)
 boto3==1.34.97
     # via cladetime (pyproject.toml)
 botocore==1.34.97
@@ -39,6 +41,7 @@ mdurl==0.1.2
     # via markdown-it-py
 numpy==1.26.4
     # via
+    #   biopython
     #   pandas
     #   pyarrow
 pandas==2.2.2

--- a/src/cladetime/sequence.py
+++ b/src/cladetime/sequence.py
@@ -333,7 +333,7 @@ def filter_sequence_data(sequence_ids: set, url_sequence: str, output_path: Path
     # of compression schemas (ZSTD) or none at all
 
     # download the original sequence file
-    logger.info("Staring sequence file download", url=url_sequence)
+    logger.info("Starting sequence file download", url=url_sequence)
     sequence_file = _download_from_url(session, url_sequence, output_path)
     logger.info("Sequence file saved", path=sequence_file)
 

--- a/src/cladetime/sequence.py
+++ b/src/cladetime/sequence.py
@@ -9,6 +9,8 @@ from urllib.parse import urlparse
 import polars as pl
 import structlog
 import us
+from Bio import SeqIO
+from Bio.SeqIO import FastaIO
 from requests import Session
 
 from cladetime.types import StateFormat
@@ -262,7 +264,7 @@ def get_sequence_set(sequence_metadata: pl.DataFrame | pl.LazyFrame) -> set:
 
     Returns
     -------
-    list
+    set
         A set of GenBank accession numbers
 
     Raises
@@ -298,3 +300,61 @@ def parse_sequence_assignments(df_assignments: pl.DataFrame) -> pl.DataFrame:
     df_assignments = df_assignments.insert_column(1, seq)  # type: ignore
 
     return df_assignments
+
+
+def filter_sequence_data(sequence_ids: set, url_sequence: str, output_path: Path) -> tuple[Path, int, int]:
+    """Filter a fasta file against a specific set of sequences.
+
+    Download a sequence file (in FASTA format) from Nexstrain, filter
+    it against a set of specific sequence ids (GenBank accession numbers),
+    and write the filtered sequences to a new file.
+
+    Parameters
+    ----------
+    sequence_ids : set
+        GenBank accession numbers used to filter the sequence file
+    url_sequence : str
+        The URL to a file of SARS-CoV-2 GenBank sequences published by Nexstrain.
+        The file is should be in .fasta format using the lzma compression
+        method (e.g., "https://data.nextstrain.org/files/ncov/open/100k/sequences.fasta.xz")
+    output_path : pathlib.Path
+        Where to save the filtered sequence file
+
+    Returns
+    -------
+    Tuple[pathlib.Path, int, int]
+        A tuple containing the full path to the filtered sequence file, the
+        number of original sequences, and the number of filtered sequences
+    """
+    session = _get_session()
+
+    # FIXME: validate url_sequence (should be in filename.fasta.xz format)
+    # alternately, we could expand this function to handle other types
+    # of compression schemas (ZSTD) or none at all
+
+    # download the original sequence file
+    logger.info("Staring sequence file download", url=url_sequence)
+    sequence_file = _download_from_url(session, url_sequence, output_path)
+    logger.info("Sequence file saved", path=sequence_file)
+
+    filtered_sequence_file = output_path / "sequences_filtered.fasta"
+
+    # create a second fasta file with only those sequences in the metadata
+    logger.info("Starting sequence filter", sequence_file=sequence_file, filtered_sequence_file=filtered_sequence_file)
+    sequence_count = 0
+    sequence_match_count = 0
+    with open(filtered_sequence_file, "w") as fasta_output:
+        with lzma.open(sequence_file, mode="rt") as handle:
+            for record in FastaIO.FastaIterator(handle):
+                sequence_count += 1
+                if record.id in sequence_ids:
+                    sequence_match_count += 1
+                    SeqIO.write(record, fasta_output, "fasta")
+    logger.info(
+        "Filtered sequence file saved",
+        num_sequences=sequence_count,
+        num_matched_sequences=sequence_match_count,
+        path=filtered_sequence_file,
+    )
+
+    return filtered_sequence_file, sequence_count, sequence_match_count

--- a/src/cladetime/util/config.py
+++ b/src/cladetime/util/config.py
@@ -17,7 +17,7 @@ class Config:
     nextstrain_ncov_bucket = "nextstrain-data"
     nextstrain_ncov_metadata_key = "files/ncov/open/metadata_version.json"
     nextstrain_genome_metadata_key = "files/ncov/open/metadata.tsv.zst"
-    nextstrain_genome_sequence_key = "files/ncov/open/sequences.fasta.zst"
+    nextstrain_genome_sequence_key = "files/ncov/open/sequences.fasta.xz"
     nextclade_data_url = "https://data.clades.nextstrain.org"
     nextclade_data_url_version = "v3"
     nextclade_base_url: str = "https://nextstrain.org/nextclade/sars-cov-2"

--- a/tests/unit/test_sequence.py
+++ b/tests/unit/test_sequence.py
@@ -28,7 +28,7 @@ def test_file_path() -> Path:
     """
     Return path to the unit test files.
     """
-    test_file_path = Path(__file__).parents[2].joinpath("data")
+    test_file_path = Path(__file__).parents[1].joinpath("data")
     return test_file_path
 
 

--- a/tests/unit/test_sequence.py
+++ b/tests/unit/test_sequence.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import polars as pl
 import pytest
+from Bio import SeqIO
 from cladetime.sequence import (
     filter_sequence_data,
     filter_sequence_metadata,
@@ -180,7 +181,6 @@ def test_get_sequence_set():
     empty_lf = pl.LazyFrame([])
     with pytest.raises(ValueError):
         seq_set = get_sequence_set(empty_lf)
-        assert len(seq_set) == 0
 
 
 def test_filter_sequence_data(test_file_path, tmpdir):
@@ -198,8 +198,14 @@ def test_filter_sequence_data(test_file_path, tmpdir):
             test_sequence_set, "http://thisismocked.com", tmpdir
         )
 
-    assert filtered_sequence_file.exists()
     assert seq_filtered == 4
+
+    test_sequence_set.remove("STARFLEET/DS9-DS9-001/2024")
+    actual_headers = []
+    with open(filtered_sequence_file, "r") as fasta_test:
+        for record in SeqIO.parse(fasta_test, "fasta"):
+            actual_headers.append(record.description)
+    assert set(actual_headers) == test_sequence_set
 
     # test with empty sequence set
     test_sequence_set = {}

--- a/tests/unit/test_sequence.py
+++ b/tests/unit/test_sequence.py
@@ -2,10 +2,7 @@ from pathlib import Path
 
 import polars as pl
 import pytest
-from cladetime.sequence import (
-    filter_sequence_metadata,
-    get_covid_genome_metadata,
-)
+from cladetime.sequence import filter_sequence_metadata, get_covid_genome_metadata, get_sequence_set
 from cladetime.types import StateFormat
 
 
@@ -155,3 +152,25 @@ def test_filter_covid_genome_metadata_state_fips():
 
     locations = set(lf_filtered["location"].to_list())
     assert locations == {"11", "25", "72"}
+
+
+def test_get_sequence_set():
+    metadata = {
+        "genbank_accession": ["A1", "A2", "A2", "A4"],
+        "country": ["USA", "Canada", "Mexico", "Brazil"],
+        "location": ["Earth", "Earth", "Earth", "Earth"],
+    }
+    expected_set = {"A1", "A2", "A4"}
+
+    lf = pl.LazyFrame(metadata)
+    seq_set = get_sequence_set(lf)
+    assert seq_set == expected_set
+
+    df = lf.collect()
+    seq_set = get_sequence_set(df)
+    assert seq_set == expected_set
+
+    empty_lf = pl.LazyFrame([])
+    with pytest.raises(ValueError):
+        seq_set = get_sequence_set(empty_lf)
+        assert len(seq_set) == 0


### PR DESCRIPTION
Closes #48 

Add a new feature that generates a filtered list of SARS-CoV-2 sequences and writes it to disk. In practice, this will be used to generate a file of sequences as input to the Nextclade CLI (for clade assignment).

This one can be reviewed commit by commit.