### PR TITLE
Add a demo mode to Cladetime

### DIFF
--- a/src/cladetime/util/config.py
+++ b/src/cladetime/util/config.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import InitVar, asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -59,6 +60,11 @@ class Config:
             self.data_path = Path(data_path_root)
         else:
             self.data_path = Path(".").home() / "covid_variant" / self.run_time
+
+        # For demo purposes, use Nextstrain's 100k sample dataset
+        if os.environ.get("CLADETIME_DEMO") == "true":
+            self.nextstrain_genome_metadata_key = "files/ncov/open/100k/metadata.tsv.xz"
+            self.nextstrain_genome_sequence_key = "files/ncov/open/100k/sequences.fasta.xz"
 
     def __repr__(self):
         return str(pprint(asdict(self)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,14 @@ from moto import mock_aws
 from cladetime.util.config import Config
 
 
+@pytest.fixture(scope="function")
+def demo_mode(monkeypatch):
+    "Set demo mode to True for tests using the Nextstrain 100K sequence files."
+    demo_mode = "true"
+    monkeypatch.setenv("CLADETIME_DEMO", demo_mode)
+    yield demo_mode
+
+
 @pytest.fixture
 def test_sequences():
     """Return a set of sequences for testing.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+import lzma
 from datetime import datetime, timezone
 
 import boto3
@@ -41,6 +42,7 @@ def ncov_metadata():
 def s3_object_keys():
     return {
         "sequence_metadata": "data/object-key/metadata.tsv.zst",
+        "sequence_metadata_xz": "data/object-key/metadata.tsv.xz",
         "sequence": "data/object-key/sequences.fasta.zst",
         "ncov_metadata": "data/object-key/metadata_version.json",
     }
@@ -92,6 +94,8 @@ def s3_setup(s3_object_keys, ncov_metadata):
                     ncov_metadata["nextclade_version_num"] = "3.8.2"
                     ncov_metadata["greeting"] = "hello from pytest and moto"
                     content = json.dumps(ncov_metadata)
+                elif key == "sequence_metadata_xz":
+                    content = lzma.compress(b"f'{value} version {i}'")
                 else:
                     content = f"{value} version {i}"
                 # use freezegun to override system date, which in


### PR DESCRIPTION
**Background**

This morning's Cladetime demo showed that it's hard to fully demonstrate the package interactively because it's designed to operate against the full set of SARS-CoV-2 sequence and metadata files published by Nextstrain.

As part of the their daily pipeline, Nextstrain also [publishes a subset of 100K samples](https://docs.nextstrain.org/projects/ncov/en/latest/reference/remote_inputs.html#k-subsamples).

This changeset adds the ability to set an environment variable that instructs Cladetime to use the 100k dataset. We wouldn't do this in any production scripts, but being able to use the smaller datasets during demos makes it easier to explain how Cladetime works (and could also be a handy option for people learning to use the package).

I didn't include documentation for this feature in the PR, since the next PR is documentation updates.

**Testing**

```bash
export CLADETIME_DEMO="true"
```

```python
from cladetime import CladeTime, sequence
import polars as pl

ct = CladeTime(sequence_as_of="2024-11-11", tree_as_of="2024-09-01")
clade_assignments = ct.assign_clades(sequence.filter_metadata(ct.sequence_metadata, collection_min_date="2024-10-01"))

2024-11-18 18:40:11 [info     ] Starting clade assignment pipeline num_sequence=1240 sequence_as_of=datetime.datetime(2024, 11, 11, 0, 0, tzinfo=datetime.timezone.utc) tree_as_of=datetime.datetime(2024, 9, 1, 0, 0, tzinfo=datetime.timezone.utc)
2024-11-18 18:40:11 [info     ] Collecting sequence IDs from metadata
2024-11-18 18:40:12 [info     ] Starting sequence file download url=https://nextstrain-data.s3.amazonaws.com/files/ncov/open/100k/sequences.fasta.xz?versionId=8vi7wU5YXISjaFPK9SbRME4BiOqkSIkX
2024-11-18 18:40:16 [info     ] '_download_from_url' complete  elapsed_seconds=3.88
2024-11-18 18:40:16 [info     ] Sequence file saved            path=PosixPath('/var/folders/w5/zth_l81n3sz0rq991035myy1hqz_1_/T/tmpgr6uv42i/sequences.fasta.xz')
2024-11-18 18:40:16 [info     ] Starting sequence filter       filtered_sequence_file=PosixPath('/var/folders/w5/zth_l81n3sz0rq991035myy1hqz_1_/T/tmpgr6uv42i/sequences_filtered.fasta') sequence_file=PosixPath('/var/folders/w5/zth_l81n3sz0rq991035myy1hqz_1_/T/tmpgr6uv42i/sequences.fasta.xz')
2024-11-18 18:40:28 [info     ] Filtered sequence file saved   num_matched_sequences=1240 num_sequences=99468 path=PosixPath('/var/folders/w5/zth_l81n3sz0rq991035myy1hqz_1_/T/tmpgr6uv42i/sequences_filtered.fasta')
2024-11-18 18:40:28 [info     ] 'filter' complete              elapsed_seconds=16.53
2024-11-18 18:40:30 [info     ] Assigning clades               nextclade_dataset_version=2024-07-17--12-57-03Z sequences_to_assign=1240
2024-11-18 18:40:34 [info     ] Clade assignments done         assignment_file=PosixPath('/Users/rsweger/cladetime/clade_assignments.csv') nextclade_dataset=2024-07-17--12-57-03Z

# detailed clade assignments
clade_assignments.detail.collect().select(["country", "date", "strain", "location", "clade_nextstrain"]).head()

shape: (5, 5)
┌─────────┬────────────┬─────────────────────┬──────────┬──────────────────┐
│ country ┆ date       ┆ strain              ┆ location ┆ clade_nextstrain │
│ ---     ┆ ---        ┆ ---                 ┆ ---      ┆ ---              │
│ str     ┆ date       ┆ str                 ┆ str      ┆ str              │
╞═════════╪════════════╪═════════════════════╪══════════╪══════════════════╡
│ USA     ┆ 2024-10-01 ┆ USA/2024CV1711/2024 ┆ AZ       ┆ 24C              │
│ USA     ┆ 2024-10-02 ┆ USA/2024CV1718/2024 ┆ AZ       ┆ 24C              │
│ USA     ┆ 2024-10-04 ┆ USA/2024CV1719/2024 ┆ AZ       ┆ 24C              │
│ USA     ┆ 2024-10-05 ┆ USA/2024CV1721/2024 ┆ AZ       ┆ 24C              │
│ USA     ┆ 2024-10-06 ┆ USA/2024CV1722/2024 ┆ AZ       ┆ recombinant      │
└─────────┴────────────┴─────────────────────┴──────────┴──────────────────┘

# clade assignments summarized by date and location
clade_assignments.summary.collect().head()

shape: (5, 6)
┌──────────┬────────────┬──────────────┬──────────────────┬─────────┬───────┐
│ location ┆ date       ┆ host         ┆ clade_nextstrain ┆ country ┆ count │
│ ---      ┆ ---        ┆ ---          ┆ ---              ┆ ---     ┆ ---   │
│ str      ┆ date       ┆ str          ┆ str              ┆ str     ┆ u32   │
╞══════════╪════════════╪══════════════╪══════════════════╪═════════╪═══════╡
│ NJ       ┆ 2024-10-01 ┆ Homo sapiens ┆ 24C              ┆ USA     ┆ 9     │
│ NY       ┆ 2024-10-14 ┆ Homo sapiens ┆ 24C              ┆ USA     ┆ 16    │
│ NY       ┆ 2024-10-20 ┆ Homo sapiens ┆ 24C              ┆ USA     ┆ 6     │
│ FL       ┆ 2024-10-03 ┆ Homo sapiens ┆ 24A              ┆ USA     ┆ 1     │
│ TX       ┆ 2024-10-08 ┆ Homo sapiens ┆ 24C              ┆ USA     ┆ 1     │
└──────────┴────────────┴──────────────┴──────────────────┴─────────┴───────┘