### PR TITLE
Bump polars and set minimum version to avoid kernal panic bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "cloudpathlib",
     "docker",
     "pandas",
-    "polars>=1.0.0",
+    "polars>=1.17.1",
     "pyarrow",
     "requests>=2.32.0",
     "rich",

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -80,7 +80,7 @@ pandas==2.2.3
     # via cladetime (pyproject.toml)
 pluggy==1.5.0
     # via pytest
-polars==1.12.0
+polars==1.17.1
     # via cladetime (pyproject.toml)
 pyarrow==18.0.0
     # via cladetime (pyproject.toml)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -45,7 +45,7 @@ numpy==2.1.3
     #   pandas
 pandas==2.2.3
     # via cladetime (pyproject.toml)
-polars==1.12.0
+polars==1.17.1
     # via cladetime (pyproject.toml)
 pyarrow==18.0.0
     # via cladetime (pyproject.toml)


### PR DESCRIPTION
This changeset targets the Polars 1.17.1 release, which fixes a bug that was impacting downstream cladetime users 

- bug: https://github.com/pola-rs/polars/issues/20216 
- release: https://github.com/pola-rs/polars/releases/tag/py-1.17.1