### PR TITLE
Output clade assignments as tsv instead of csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,5 +206,5 @@ custom clade assignments without needed to write Python code.
 The CLI is not yet implemented, but it will look something like this:
 
 ```bash
-assign_clades --sequence-as-of 2024-10-15 --tree-as-of 2024-09-01 --min-collection-date 2024-09-01 --max-collection-date 2024-09-30 --output-file clade_assignments.csv
+assign_clades --sequence-as-of 2024-10-15 --tree-as-of 2024-09-01 --min-collection-date 2024-09-01 --max-collection-date 2024-09-30 --output-file clade_assignments.tsv
 ```

--- a/src/cladetime/cladetime.py
+++ b/src/cladetime/cladetime.py
@@ -229,9 +229,9 @@ class CladeTime:
             :external+ncov:doc:`sequence metadata<reference/metadata-fields>`
             to use for clade assignment.
         output_file : str | None
-            The full path (including filename) to where the clade assignment
-            output file will be saved. The default value is
-            <home_dir>/cladetime/clade_assignments.csv.
+            The full path (including a .tsv filename) to where the clade
+            assignment output file will be saved. The default value is
+            <home_dir>/cladetime/clade_assignments.tsv.
 
         Returns
         -------
@@ -279,7 +279,7 @@ class CladeTime:
         if output_file is not None:
             output_file = Path(output_file)
         else:
-            output_file = Path.home() / "cladetime" / "clade_assignments.csv"
+            output_file = Path.home() / "cladetime" / "clade_assignments.tsv"
 
         logger.info(
             "Starting clade assignment pipeline", sequence_as_of=self.sequence_as_of, tree_as_of=self.tree_as_of
@@ -344,7 +344,7 @@ class CladeTime:
                 nextclade_dataset=tree.ncov_metadata.get("nextclade_dataset_version"),
             )
 
-            assigned_clades = pl.read_csv(assignments, separator=";", infer_schema_length=100000)
+            assigned_clades = pl.read_csv(assignments, separator="\t", infer_schema_length=100000)
 
         # join the assigned clades with the original sequence metadata, create a summarized LazyFrame
         # of clade counts by location, date, and host, and return both (along with metadata) in a

--- a/src/cladetime/util/reference.py
+++ b/src/cladetime/util/reference.py
@@ -190,7 +190,7 @@ def _get_clade_assignments(
 
     Invoke the Nextclade CLI :external:doc:`dataset run<user/nextclade-cli/usage>`
     command and save the resulting clade assignment file to disk. The clade
-    assignment file will be in CSV format.
+    assignment file will be in TSV format.
 
     Parameters
     ----------
@@ -238,7 +238,7 @@ def _get_clade_assignments(
         "run",
         "--input-dataset",
         f"/data/{nextclade_dataset.name}",
-        "--output-csv",
+        "--output-tsv",
         f"/data/{assignment_filename}",
         f"/data/{sequence_file.name}",
     ]

--- a/tests/integration/test_cladetime_integration.py
+++ b/tests/integration/test_cladetime_integration.py
@@ -17,7 +17,7 @@ docker_enabled = _docker_installed()
 def test_cladetime_assign_clades(tmp_path, demo_mode):
     # demo_mode fixture overrides CladeTime config to use Nextstrain's 100k sample
     # sequence and sequence metadata instead of the entire universe of SARS-CoV-2 sequences
-    assignment_file = tmp_path / "assignments.csv"
+    assignment_file = tmp_path / "assignments.tsv"
 
     with freeze_time("2024-11-01"):
         ct = CladeTime()
@@ -79,13 +79,13 @@ def test_assign_old_tree(test_file_path, tmp_path, test_sequences):
     expected_assignments = pl.DataFrame(expected_assignment_dict)
 
     with freeze_time("2024-11-01"):
-        current_file = tmp_path / "current_assignments.csv"
+        current_file = tmp_path / "current_assignments.tsv"
         ct_current_tree = CladeTime()
         with patch("cladetime.sequence.filter", fasta_mock):
             current_assigned_clades = ct_current_tree.assign_clades(metadata_filtered, output_file=current_file)
             current_assigned_clades = current_assigned_clades.detail.select(["strain", "clade"]).collect()
 
-        old_file = tmp_path / "old_assignments.csv"
+        old_file = tmp_path / "old_assignments.tsv"
         ct_old_tree = CladeTime(tree_as_of="2024-08-02")
         with patch("cladetime.sequence.filter", fasta_mock):
             old_assigned_clades = ct_old_tree.assign_clades(metadata_filtered, output_file=old_file)
@@ -140,7 +140,7 @@ def test_assign_date_filters(test_file_path, tmp_path, test_sequences, min_date,
     )
 
     ct = CladeTime()
-    assignment_file = tmp_path / "assignments.csv"
+    assignment_file = tmp_path / "assignments.tsv"
     with patch("cladetime.sequence.filter", fasta_mock):
         assigned_clades = ct.assign_clades(metadata_filtered, output_file=assignment_file)
     assert len(assigned_clades.detail.collect()) == expected_rows
@@ -157,7 +157,7 @@ def test_assign_too_many_sequences_warning(tmp_path, test_file_path, test_sequen
     fasta_mock = MagicMock(return_value=test_file_path / sequence_file, name="cladetime.sequence.filter")
     with patch("cladetime.sequence.filter", fasta_mock):
         with pytest.warns(CladeTimeSequenceWarning):
-            assignments = ct.assign_clades(metadata_filtered, output_file=tmp_path / "assignments.csv")
+            assignments = ct.assign_clades(metadata_filtered, output_file=tmp_path / "assignments.tsv")
             # clade assignment should proceed, despite the warning
             assert len(assignments.detail.collect()) == 3
 

--- a/tests/integration/test_nextclade_integration.py
+++ b/tests/integration/test_nextclade_integration.py
@@ -32,10 +32,10 @@ def test_get_clade_assignments(test_file_path, tmp_path):
     sequence_file = test_file_path / "test_sequences.fasta"
     nextclade_dataset = test_file_path / "test_nextclade_dataset.zip"
     # _get_clade_assignments should create the output directory if it doesn't exist
-    output_file = tmp_path / "clade_assignments" / "nextclade_assignments.csv"
+    output_file = tmp_path / "clade_assignments" / "nextclade_assignments.tsv"
 
     assignment_file = _get_clade_assignments("latest", sequence_file, nextclade_dataset, output_file)
-    assignment_df = pl.read_csv(assignment_file, separator=";").select(
+    assignment_df = pl.read_csv(assignment_file, separator="\t").select(
         ["seqName", "clade", "clade_nextstrain", "Nextclade_pango"]
     )
 
@@ -50,10 +50,10 @@ def test_get_clade_assignments_no_matches(test_file_path, tmp_path):
     sequence_file = test_file_path / "test_sequences_fake.fasta"
     nextclade_dataset = test_file_path / "test_nextclade_dataset.zip"
     # _get_clade_assignments should create the output directory if it doesn't exist
-    output_file = tmp_path / "clade_assignments" / "nextclade_assignments.csv"
+    output_file = tmp_path / "clade_assignments" / "nextclade_assignments.tsv"
 
     assignment_file = _get_clade_assignments("latest", sequence_file, nextclade_dataset, output_file)
-    assignment_df = pl.read_csv(assignment_file, separator=";").select(
+    assignment_df = pl.read_csv(assignment_file, separator="\t").select(
         ["seqName", "clade", "clade_nextstrain", "Nextclade_pango"]
     )
 


### PR DESCRIPTION
Closes #70

Cladetime was requesting .csv output from Nextclade's assignment utility (with a semicolon delimiter).

That's not a good choice, since some of the genomic information returned by Nextclade has embedded semicolons. This PR switches us from .csv to .tsv to match the rest of Cladetime's data wrangling operations.
