### PR TITLE
Bump jinja2 version to address security alert

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "boto3-stubs[s3]",
     "coverage",
     "freezegun",
+    "jinja2>3.1.4",
     "moto",
     "mypy",
     "pytest",
@@ -51,6 +52,7 @@ dev = [
 ]
 docs = [
     "furo",
+    "jinja2>3.1.4",
     "matplotlib",
     "myst-parser",
     "sphinx>=5.0,<6.0",

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -48,8 +48,10 @@ iniconfig==2.0.0
     # via pytest
 jellyfish==1.1.0
     # via us
-jinja2==3.1.4
-    # via moto
+jinja2==3.1.5
+    # via
+    #   cladetime (pyproject.toml)
+    #   moto
 jmespath==1.0.1
     # via
     #   boto3

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -90,8 +90,9 @@ imagesize==1.4.1
     # via sphinx
 jellyfish==1.1.0
     # via us
-jinja2==3.1.4
+jinja2==3.1.5
     # via
+    #   cladetime (pyproject.toml)
     #   myst-parser
     #   sphinx
     #   sphinx-jinja2-compat
@@ -140,7 +141,7 @@ pillow==11.0.0
     # via matplotlib
 platformdirs==4.3.6
     # via apeye
-polars==1.13.1
+polars==1.18.0
     # via cladetime (pyproject.toml)
 pyarrow==18.0.0
     # via cladetime (pyproject.toml)
@@ -252,6 +253,8 @@ structlog==24.4.0
     # via cladetime (pyproject.toml)
 tabulate==0.9.0
     # via sphinx-toolbox
+tqdm==4.67.1
+    # via cladetime (pyproject.toml)
 typing-extensions==4.12.2
     # via
     #   domdf-python-tools
@@ -275,3 +278,5 @@ webencodings==0.5.1
     # via html5lib
 websockets==14.1
     # via sphinx-autobuild
+zstandard==0.23.0
+    # via cladetime (pyproject.toml)


### PR DESCRIPTION
Dependabot raised four alerts related to the `jinja2` package, all of which can be addressed by bumping to a version > 3.14.

https://github.com/reichlab/cladetime/security/dependabot