### PR TITLE
Deploy cladetime to test-pypi

### DIFF
--- a/.github/workflows/publish-pypi-test.yaml
+++ b/.github/workflows/publish-pypi-test.yaml
@@ -1,0 +1,61 @@
+# .github/workflows/publish-pypi-test.yaml
+# uses trusted publishing to publish the package to TestPyPI as described here:
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+name: Publish to Test PyPI
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 🐍
+        uses: actions/setup-python@v5
+
+      - name: Install uv 🌟
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: ">=0.0.1"
+
+      - name: Build package for distribution 🛠️
+        run: |
+          uv build
+
+      - name: Upload distribution packages 📤
+        uses: actions/upload-artifact@v4
+        with:
+          name: cladetime-package-distribution
+          path: dist/
+
+  publish-to-testpypi:
+    name: Publish Python distribution to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi-test
+      url: https://test.pypi.org/p/cladetime
+    permissions:
+       id-token: write  # needed for trusted publishing (i.e., OIDC)
+
+    steps:
+    - name: Download distribution artifacts 📥
+      uses: actions/download-artifact@v4
+      with:
+        name: cladetime-package-distributions
+        path: dist/
+    - name: Publish distribution to TestPyPI 🚀
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,30 @@
 [project]
 name = "cladetime"
-version = "0.2.0"
-description = "Assign clades to viral genome sequences at a point in time."
+version = "0.2.2"
+description = "Assign clades to SARS-CoV-2 genome sequences at a point in time."
 authors = [
+    {name = "Reich Lab @ University of Massachusetts", email = "nick@umass.edu"},
+]
+maintainers = [
+    {name = "Becky Sweger", email = "rsweger@umass.edu"},
     {name = "Evan Ray", email="elray@umass.edu"},
     {name = "Ben Rogers", email = "bwrogers@umass.edu"},
-    {name = "Becky Sweger", email = "rsweger@umass.edu"},
+]
+license = {text = "MIT License"}
+keywords = ["biostatistics", "clade", "covid", "epidemiology", "genome", "sequence"]
+
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "License :: OSI Approved :: MIT License",
+  "Natural Language :: English",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 
 requires-python = ">=3.11"
 readme = "README.md"
-
-classifiers = [
-  "Development Status :: 3 - Alpha",
-  "License :: OSI Approved :: MIT License",
-]
 
 dependencies = [
     "awscli>=1.32.92",
@@ -59,7 +69,7 @@ docs = [
     "sphinx-github-style",
     "sphinxext-opengraph",
     "sphinx_toolbox",
-    ]
+]
 
 [project.urls]
 Repository = "https://github.com/reichlab/cladetime.git"
@@ -69,6 +79,10 @@ Issues = "https://github.com/reichlab/cladetime/issues"
 [build-system]
 requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+namespaces = true
+where = ["src"]
 
 [tool.pytest.ini_options]
 tmp_path_retention_policy = "none"
@@ -89,9 +103,5 @@ lint.extend-select = ["I"]
 # Ignore import formatting rules in `__init__.py`
 "__init__.py" = ["I001"]
 
-[tools.setuptools]
-packages = ["cladetime"]
-
 [tool.mypy]
 ignore_missing_imports = true
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cladetime"
-version = "0.2.2"
+version = "0.2.3"
 description = "Assign clades to SARS-CoV-2 genome sequences at a point in time."
 authors = [
     {name = "Reich Lab @ University of Massachusetts", email = "nick@umass.edu"},


### PR DESCRIPTION
## Background

This PR is a starting point for getting [Cladetime to PyPI.](https://github.com/reichlab/cladetime/issues/80#issue-2775943649). It adds a new workflow based on part of the instructions here:
https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

- Builds the distribution package
- Publishes it to test-pypi

Out of scope for the PR:

- Signing the package and uploading to GitHub releases
- Tagging stuff
- Publishing to PyPI proper

## Implementation

- **one time step:** create a Cladetime trusted publisher on test-pypi (done)

![image](https://github.com/user-attachments/assets/ca765065-4768-4245-96e3-f67e053e40dc)

- add a GitHub workflow to build and publish the package:
    - [uv does the build](https://docs.astral.sh/uv/reference/cli/#uv-build) (not strictly necessary, since we're using the setuptools build backend, but laying groundwork for more future uv things)
    - The Python Packaging Authority's (PyPA) [gh-action-pypi-publish action](https://github.com/pypa/gh-action-pypi-publish) publishes to test-pypi. This action supports [PyPi's trusted publisher feature](https://docs.pypi.org/trusted-publishers/) (aka PyPi's OIDC provider)

## Reviewing and testing

- Are there any changes needed to the package metadata as it's displayed on test-pypi: https://test.pypi.org/project/cladetime/?

Because this is a new workflow, we'll like need to merge the PR before trying the following:

- Can we run the new `publish-pypi-test.yaml` workflow successfully?
- Manual approval should be required before the `publish-to-pypi-test` job executes

