### PR TITLE
Replace manual package version with setuptools_scm

### DIFF
--- a/.github/workflows/publish-pypi-test.yaml
+++ b/.github/workflows/publish-pypi-test.yaml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cladetime"
-version = "0.2.3"
+dynamic = ["version"]
 description = "Assign clades to SARS-CoV-2 genome sequences at a point in time."
 authors = [
     {name = "Reich Lab @ University of Massachusetts", email = "nick@umass.edu"},
@@ -77,12 +77,14 @@ Documentation = "https://cladetime.readthedocs.io/"
 Issues = "https://github.com/reichlab/cladetime/issues"
 
 [build-system]
-requires = ["setuptools>=64", "wheel"]
+requires = ["setuptools>=64", "wheel", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 namespaces = true
 where = ["src"]
+
+[tool.setuptools_scm]
 
 [tool.pytest.ini_options]
 tmp_path_retention_policy = "none"


### PR DESCRIPTION
This PR incorporates changes that will set us up for success now that we've tested the the [publish-pypi-test.yaml](https://github.com/reichlab/cladetime/blob/main/.github/workflows/publish-pypi-test.yaml) workflow: https://github.com/reichlab/cladetime/actions/runs/12694265607

Assuming that we'll build and publish to test-pypi on every push to the main branch, I've made the following changes outside of this PR:

- Remove the "required reviewers" protection from this repo's [pypi-test environment](https://github.com/reichlab/cladetime/settings/environments/5139998192/edit) (test-pypi doesn't require a manual review)
- Added a local v0.2.3 tag to Cladetime as a seed for introducing the `setuptools_scm` automated tagging package (mostly because test-pypi is on v0.2.3, so updates going forward should be `v0.2.3.devwhatever`)

The main coding change in the PR is removing the manual version number in `pyproject.toml` and replacing it with `setuptools_scm` to automatically version Cladetime.

For example, after I created the local `v0.2.3` tag, I used setuptools_scm to retrieve the next version:

```
➜ python -m setuptools_scm
0.2.4.dev1+gad61105
```

Next steps:

- Set up a pypi GitHub environment (with required reviewers) and a corresponding trusted publisher on the real PyPI
- Create a publish-pypi workflow that publishes to PyPI and adds the build artifacts to GitHub Release (to be triggered on a tag push). [pypa template for this](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#the-whole-ci-cd-workflow)