### PR TITLE
Make development auto-generated package versions PEP 440 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ namespaces = true
 where = ["src"]
 
 [tool.setuptools_scm]
+local_scheme = "no-local-version"
 
 [tool.pytest.ini_options]
 tmp_path_retention_policy = "none"
@@ -106,4 +107,5 @@ lint.extend-select = ["I"]
 "__init__.py" = ["I001"]
 
 [tool.mypy]
-ignore_missing_imports = true
+ignore_missing_imports = false
+


### PR DESCRIPTION
Out of the box, setuptools_scm generates development package versions in a format that doesn't comply with [PEP 440](https://peps.python.org/pep-0440/), so the test-pypi publish workflow failed.

That's by design, to prevent dev releases going to PyPI. However, our prod PyPI workflow will trigger only when a tag in the format v[0-9].[0-9].[0-9] is pushed to GitHub, so the liklihood of inadvertently publishing a dev version to PyPI is low.

I also pushed my local v0.2.3 release tag to the repo to make sure setuptools_scm uses that as the baseline when generating new dev tags.

On my local machine, setuptools_scm recognized the tag and versioned subsequent commits as follows:
```
➜ python -m setuptools_scm
0.2.4.dev1
```
