### PR TITLE
Configure uv to use git commits and tags in cache key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,3 +109,8 @@ lint.extend-select = ["I"]
 [tool.mypy]
 ignore_missing_imports = false
 
+[tool.uv]
+# ensure setuptools_scm generates a version number that reflects latest tags
+# https://docs.astral.sh/uv/concepts/cache/#dynamic-metadata
+cache-keys = [{ git = { commit = true, tags = true } }]
+


### PR DESCRIPTION
This is another attempt to make setuptools-scm work as intended when using the publish to test-pypi workflow. We previously configured setuptools-scm to generate PEP 440-compliant version numbers, and that change enabled a successful push to test-pypi.

However, the version number generated by setuptools-scm did not respect the most recent tagged release of Cladetime (v.0.2.3), and assigned a version number of cladetime-0.1.dev1 rather than the expected v.0.2.4.dev[somenumber]

The changeset follows uv guidance for using setuptools-scm/dynamic metadata: https://docs.astral.sh/uv/concepts/cache/#dynamic-metadata