### PR TITLE
A few more updates for index publication

### DIFF
--- a/.github/workflows/publish-pypi-test.yaml
+++ b/.github/workflows/publish-pypi-test.yaml
@@ -17,6 +17,7 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python 🐍

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ will install the version of Python specified in
 [.python-version](.python-version).
 
     ```bash
-    uv venv
+    uv venv --seed
     ```
 
 5. Install the project's dependencies, including an editable copy of the


### PR DESCRIPTION
This PR contains two unrelated commits that tweak a few things to ensure that Cladetime is ready for PyPI and test-PyPI