### PR TITLE
Use biobear to read ZSTD-compressed .fasta files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python 🐍
         uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ readme = "README.md"
 
 dependencies = [
     "awscli>=1.32.92",
+    "biobear",
     "biopython",
     "boto3",
     "cloudpathlib",

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -2,6 +2,8 @@
 #    uv pip compile pyproject.toml --extra dev -o requirements/requirements-dev.txt
 awscli==1.35.20
     # via cladetime (pyproject.toml)
+biobear==0.23.5
+    # via cladetime (pyproject.toml)
 biopython==1.84
     # via cladetime (pyproject.toml)
 boto3==1.35.54
@@ -81,7 +83,9 @@ pluggy==1.5.0
 polars==1.17.1
     # via cladetime (pyproject.toml)
 pyarrow==18.0.0
-    # via cladetime (pyproject.toml)
+    # via
+    #   cladetime (pyproject.toml)
+    #   biobear
 pyasn1==0.6.1
     # via rsa
 pycparser==2.22

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,8 @@
 #    uv pip compile pyproject.toml -o requirements/requirements.txt
 awscli==1.35.20
     # via cladetime (pyproject.toml)
+biobear==0.23.5
+    # via cladetime (pyproject.toml)
 biopython==1.84
     # via cladetime (pyproject.toml)
 boto3==1.35.54
@@ -44,7 +46,9 @@ pandas==2.2.3
 polars==1.17.1
     # via cladetime (pyproject.toml)
 pyarrow==18.0.0
-    # via cladetime (pyproject.toml)
+    # via
+    #   cladetime (pyproject.toml)
+    #   biobear
 pyasn1==0.6.1
     # via rsa
 pygments==2.18.0

--- a/src/cladetime/cladetime.py
+++ b/src/cladetime/cladetime.py
@@ -315,6 +315,18 @@ class CladeTime:
         else:
             logger.info("Sequence count complete", sequence_count=sequence_count)
 
+        # if there are many sequences in the filtered metadata, warn that clade assignment will
+        # take a long time and require a lot of resources
+        if sequence_count > self._config.clade_assignment_warning_threshold:
+            msg = (
+                f"Sequence count is {sequence_count}: clade assignment will run longer than usual. "
+                "You may want to run clade assignments on smaller subsets of sequences."
+            )
+            warnings.warn(
+                msg,
+                category=CladeTimeSequenceWarning,
+            )
+
         tree = Tree(self.tree_as_of, self.url_sequence)
 
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/src/cladetime/cladetime.py
+++ b/src/cladetime/cladetime.py
@@ -319,7 +319,7 @@ class CladeTime:
         # take a long time and require a lot of resources
         if sequence_count > self._config.clade_assignment_warning_threshold:
             msg = (
-                f"About to assign clades to {sequence_count} sequnces \n" 
+                f"About to assign clades to {sequence_count} sequences. \n" 
                 "The assignment process is resource intensive. \n"
                 "Depending on the limitations of your machine, \n"
                 "you may want to use a smaller subset of sequences."

--- a/src/cladetime/cladetime.py
+++ b/src/cladetime/cladetime.py
@@ -289,6 +289,7 @@ class CladeTime:
 
         # drop any clade-related columns from sequence_metadata (if any exists, it will be replaced
         # by the results of the clade assignment)
+        logger.info("Removing current sequence assignments from metadata")
         sequence_metadata = sequence_metadata.drop(
             [
                 col

--- a/src/cladetime/cladetime.py
+++ b/src/cladetime/cladetime.py
@@ -319,8 +319,10 @@ class CladeTime:
         # take a long time and require a lot of resources
         if sequence_count > self._config.clade_assignment_warning_threshold:
             msg = (
-                f"Sequence count is {sequence_count}: clade assignment will run longer than usual. "
-                "You may want to run clade assignments on smaller subsets of sequences."
+                f"About to assign clades to {sequence_count} sequnces \n" 
+                "The assignment process is resource intensive. \n"
+                "Depending on the limitations of your machine, \n"
+                "you may want to use a smaller subset of sequences."
             )
             warnings.warn(
                 msg,

--- a/src/cladetime/cladetime.py
+++ b/src/cladetime/cladetime.py
@@ -315,18 +315,6 @@ class CladeTime:
         else:
             logger.info("Sequence count complete", sequence_count=sequence_count)
 
-        # if there are many sequences in the filtered metadata, warn that clade assignment will
-        # take a long time and require a lot of resources
-        if sequence_count > self._config.clade_assignment_warning_threshold:
-            msg = (
-                f"Sequence count is {sequence_count}: clade assignment will run longer than usual. "
-                "You may want to run clade assignments on smaller subsets of sequences."
-            )
-            warnings.warn(
-                msg,
-                category=CladeTimeSequenceWarning,
-            )
-
         tree = Tree(self.tree_as_of, self.url_sequence)
 
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/src/cladetime/sequence.py
+++ b/src/cladetime/sequence.py
@@ -463,7 +463,6 @@ def filter(sequence_ids: set, url_sequence: str, output_path: Path) -> Path:
 
     with open(filtered_sequence_file, "w") as fasta_output:
         if file_extension == ".xz":
-            # with open(filtered_sequence_file, "w") as fasta_output:
             if file_extension == ".xz":
                 with lzma.open(sequence_file, mode="rt") as handle:
                     for record in FastaIO.FastaIterator(handle):
@@ -490,7 +489,7 @@ def filter(sequence_ids: set, url_sequence: str, output_path: Path) -> Path:
                 # zip the above lists into a final list of biopython SeqRecord
                 # objects that match one of the sequence_ids passed to this function
                 seq_match_list = [
-                    SeqRecord(Seq(sequence), id=id)
+                    SeqRecord(Seq(sequence), id=id, description=id)
                     for id, sequence in zip(id_list, sequence_list)
                     if id in sequence_ids
                 ]

--- a/src/cladetime/sequence.py
+++ b/src/cladetime/sequence.py
@@ -463,13 +463,12 @@ def filter(sequence_ids: set, url_sequence: str, output_path: Path) -> Path:
 
     with open(filtered_sequence_file, "w") as fasta_output:
         if file_extension == ".xz":
-            if file_extension == ".xz":
-                with lzma.open(sequence_file, mode="rt") as handle:
-                    for record in FastaIO.FastaIterator(handle):
-                        sequence_count += 1
-                        if record.id in sequence_ids:
-                            sequence_match_count += 1
-                            SeqIO.write(record, fasta_output, "fasta")
+            with lzma.open(sequence_file, mode="rt") as handle:
+                for record in FastaIO.FastaIterator(handle):
+                    sequence_count += 1
+                    if record.id in sequence_ids:
+                        sequence_match_count += 1
+                        SeqIO.write(record, fasta_output, "fasta")
         else:
             # for .zst files, use biobear + polars to read the .fasta file
             # and filter it in batches (instead of reading the the fasta file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,17 @@ def moto_file_path() -> Path:
 
 @pytest.fixture(scope="function")
 def demo_mode(monkeypatch):
-    "Set demo mode to True for tests using the Nextstrain 100K sequence files."
+    """
+    Set demo mode to True for testing.
+
+    This fixture activates CladeTime's demo mode, which uses the Nextstrain
+    100k dataset instead of the entire universe of SARS-CoV-2 sequences.
+
+    Use with caution: the 100K dataset is compressed using LSTD, which
+    follows a different code path than the full dataset normally used by
+    Cladetime (which is compressed using ZSTD and is read in batches
+    using biobear).
+    """
     demo_mode = "true"
     monkeypatch.setenv("CLADETIME_DEMO", demo_mode)
     yield demo_mode

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -4,7 +4,7 @@ This directory contains test files used by CladeTime's test suite.
 
 * `moto_fixture` directory contains files used when recreating Nextstrain/Nextclade data in the moto mocked S3 bucket
 * `test_metadata.tsv` was used to test `get_clade_list` before that functionality moved to variant-nowcast-hub
-* `metadata.tsv.xz` and `metadata.tsv.xz` are used to test setting CladeTime's sequence_metadata property.
+* `metadata.tsv.xz` and `metadata.tsv.zst` are used to test setting CladeTime's sequence_metadata property.
 * `test_sequences.fasta` isn't used by tests directly, but is the human-readable version of test_sequences.fasta.[xz|zst] below
 * `test_sequences.fasta.xz` and `test_sequences.fasta.zst` are used to test the sequence filter function
 * `test_sequences.fasta`, `test_sequences_fake.fasta`, and `test_nexclade_dataset.zip` are used in Nextclade integration tests

--- a/tests/integration/test_cladetime_integration.py
+++ b/tests/integration/test_cladetime_integration.py
@@ -130,7 +130,7 @@ def test_assign_clade_detail(test_file_path, tmpdir, sequence_file):
     mock_download = MagicMock(return_value=test_sequence_file, name="_download_from_url_mock")
     with patch("cladetime.sequence._download_from_url", mock_download):
         ct = CladeTime()
-        ct.url_sequence = test_sequence_file.as_uri()
+        ct.url_sequence = test_sequence_file.as_uri()  # used to determine extension when reading .fasta file
         test_metadata = pl.read_csv(test_file_path / "metadata.tsv.zst", separator="\t", infer_schema_length=100000) \
             .filter(pl.col("strain").is_in(expected_sequence_assignments.keys())) \
             .lazy()
@@ -145,6 +145,35 @@ def test_assign_clade_detail(test_file_path, tmpdir, sequence_file):
         strain_clade_dict = detailed_df.select("strain", "clade_nextstrain").to_dicts()
         for item in strain_clade_dict:
             assert expected_sequence_assignments[item["strain"]] == item["clade_nextstrain"]
+
+        # check metadata
+        assert clades.meta.get("sequences_to_assign") == 1
+        assert clades.meta.get("sequences_assigned") == 1
+
+
+@pytest.mark.skipif(not docker_enabled, reason="Docker is not installed")
+@pytest.mark.parametrize("sequence_file", ["test_sequences.fasta.xz", "test_sequences.fasta.zst"])
+def test_assign_clade_detail_missing_assignments(test_file_path, tmpdir, sequence_file):
+    """Test the final clade assignment linefile when some sequences are not assigned clades."""
+    test_sequence_file = test_file_path / sequence_file
+
+    mock_download = MagicMock(return_value=test_sequence_file, name="_download_from_url_mock")
+    with patch("cladetime.sequence._download_from_url", mock_download):
+        ct = CladeTime()
+        ct.url_sequence = test_sequence_file.as_uri()  # used to determine extension when reading .fasta file
+        test_metadata = pl.read_csv(test_file_path / "metadata.tsv.zst", separator="\t", infer_schema_length=100000).lazy()
+        test_metadata_count = len(test_metadata.collect())
+
+        clades = ct.assign_clades(test_metadata, output_file=tmpdir / "assignments.tsv")
+        detailed_df = clades.detail.collect()
+
+        # assign_clades detail output should have the same number of records as the input metadata
+        assert len(detailed_df) == test_metadata_count
+
+        # check metadata
+        # only one sequence in the test metadata is in the test fasta
+        assert clades.meta.get("sequences_to_assign") == test_metadata_count
+        assert clades.meta.get("sequences_assigned") == 1
 
 
 @pytest.mark.skipif(not docker_enabled, reason="Docker is not installed")

--- a/tests/integration/test_cladetime_integration.py
+++ b/tests/integration/test_cladetime_integration.py
@@ -37,7 +37,6 @@ def test_cladetime_assign_clades(tmp_path, demo_mode):
         assert len(check_clade_assignments) == len(metadata_filtered.collect())
         unmatched_clade_count = check_clade_assignments.filter(pl.col("clade").is_null()).shape[0]
         assert unmatched_clade_count == 0
-        breakpoint()
 
         # summarized clade assignments should also match summarized clade assignments from the
         # original metadata file

--- a/tests/integration/test_cladetime_integration.py
+++ b/tests/integration/test_cladetime_integration.py
@@ -37,6 +37,7 @@ def test_cladetime_assign_clades(tmp_path, demo_mode):
         assert len(check_clade_assignments) == len(metadata_filtered.collect())
         unmatched_clade_count = check_clade_assignments.filter(pl.col("clade").is_null()).shape[0]
         assert unmatched_clade_count == 0
+        breakpoint()
 
         # summarized clade assignments should also match summarized clade assignments from the
         # original metadata file
@@ -203,22 +204,6 @@ def test_assign_date_filters(test_file_path, tmp_path, test_sequences, min_date,
     with patch("cladetime.sequence.filter", fasta_mock):
         assigned_clades = ct.assign_clades(metadata_filtered, output_file=assignment_file)
     assert len(assigned_clades.detail.collect()) == expected_rows
-
-
-@pytest.mark.skipif(not docker_enabled, reason="Docker is not installed")
-def test_assign_too_many_sequences_warning(tmp_path, test_file_path, test_sequences):
-    sequence_file, sequence_set = test_sequences
-
-    ct = CladeTime()
-    ct._config.clade_assignment_warning_threshold = 2
-    test_filtered_metadata = {"date": ["2022-01-01", "2022-01-02", "2023-12-27"], "strain": ["aa", "bb", "cc"]}
-    metadata_filtered = pl.LazyFrame(test_filtered_metadata)
-    fasta_mock = MagicMock(return_value=test_file_path / sequence_file, name="cladetime.sequence.filter")
-    with patch("cladetime.sequence.filter", fasta_mock):
-        with pytest.warns(CladeTimeSequenceWarning):
-            assignments = ct.assign_clades(metadata_filtered, output_file=tmp_path / "assignments.tsv")
-            # clade assignment should proceed, despite the warning
-            assert len(assignments.detail.collect()) == 3
 
 
 @pytest.mark.parametrize("empty_input", [(pl.LazyFrame()), (pl.DataFrame()), (pl.DataFrame({"strain": []}))])

--- a/tests/integration/test_cladetime_integration.py
+++ b/tests/integration/test_cladetime_integration.py
@@ -116,6 +116,36 @@ def test_assign_old_tree(test_file_path, tmp_path, test_sequences):
     assert old_assigned_clades.meta.get("nextclade_version_num") == "3.8.2"
     assert old_assigned_clades.meta.get("assignment_as_of") == "2024-11-01 00:00"
 
+@pytest.mark.skipif(not docker_enabled, reason="Docker is not installed")
+@pytest.mark.parametrize("sequence_file", ["test_sequences.fasta.xz", "test_sequences.fasta.zst"])
+def test_assign_clade_detail(test_file_path, tmpdir, sequence_file):
+    """Test the final clade assignment linefile."""
+    test_sequence_file = test_file_path / sequence_file
+
+    # The list below represents sequences in the test fasta file AND test metadata file
+    expected_sequence_assignments = {
+        "USA/WV064580/2020": "20G"
+    }
+
+    mock_download = MagicMock(return_value=test_sequence_file, name="_download_from_url_mock")
+    with patch("cladetime.sequence._download_from_url", mock_download):
+        ct = CladeTime()
+        ct.url_sequence = test_sequence_file.as_uri()
+        test_metadata = pl.read_csv(test_file_path / "metadata.tsv.zst", separator="\t", infer_schema_length=100000) \
+            .filter(pl.col("strain").is_in(expected_sequence_assignments.keys())) \
+            .lazy()
+
+        clades = ct.assign_clades(test_metadata, output_file=tmpdir / "assignments.tsv")
+        detailed_df = clades.detail.collect()
+
+        # assign_clades detail output should have the same number of records as the input metadata
+        assert len(detailed_df) == len(expected_sequence_assignments)
+
+        # check actual clade assignments against expected assignments
+        strain_clade_dict = detailed_df.select("strain", "clade_nextstrain").to_dicts()
+        for item in strain_clade_dict:
+            assert expected_sequence_assignments[item["strain"]] == item["clade_nextstrain"]
+
 
 @pytest.mark.skipif(not docker_enabled, reason="Docker is not installed")
 @pytest.mark.parametrize(

--- a/tests/integration/test_cladetime_integration.py
+++ b/tests/integration/test_cladetime_integration.py
@@ -205,6 +205,22 @@ def test_assign_date_filters(test_file_path, tmp_path, test_sequences, min_date,
     assert len(assigned_clades.detail.collect()) == expected_rows
 
 
+@pytest.mark.skipif(not docker_enabled, reason="Docker is not installed")
+def test_assign_too_many_sequences_warning(tmp_path, test_file_path, test_sequences):
+    sequence_file, sequence_set = test_sequences
+
+    ct = CladeTime()
+    ct._config.clade_assignment_warning_threshold = 2
+    test_filtered_metadata = {"date": ["2022-01-01", "2022-01-02", "2023-12-27"], "strain": ["aa", "bb", "cc"]}
+    metadata_filtered = pl.LazyFrame(test_filtered_metadata)
+    fasta_mock = MagicMock(return_value=test_file_path / sequence_file, name="cladetime.sequence.filter")
+    with patch("cladetime.sequence.filter", fasta_mock):
+        with pytest.warns(CladeTimeSequenceWarning):
+            assignments = ct.assign_clades(metadata_filtered, output_file=tmp_path / "assignments.tsv")
+            # clade assignment should proceed, despite the warning
+            assert len(assignments.detail.collect()) == 3
+
+
 @pytest.mark.parametrize("empty_input", [(pl.LazyFrame()), (pl.DataFrame()), (pl.DataFrame({"strain": []}))])
 def test_assign_clades_no_sequences(empty_input):
     ct = CladeTime()

--- a/tests/unit/test_sequence.py
+++ b/tests/unit/test_sequence.py
@@ -260,7 +260,7 @@ def test_filter(test_file_path, tmpdir, sequence_file):
     actual_headers = []
     with open(filtered_sequence_file, "r") as fasta_test:
         for record in SeqIO.parse(fasta_test, "fasta"):
-            actual_headers.append(record.description)
+            actual_headers.append(record.id)
     assert set(actual_headers) == test_sequence_set
 
 
@@ -271,10 +271,8 @@ def test_filter_no_sequences(test_file_path, tmpdir, sequence_file):
     test_sequence_set = {}
     mock_download = MagicMock(return_value=test_sequence_file, name="_download_from_url_mock")
     with patch("cladetime.sequence._download_from_url", mock_download):
-        filtered_no_sequence = sequence.filter(test_sequence_set, f"http://thisismocked.com/{sequence_file}", tmpdir)
-
-    contents = filtered_no_sequence.read_text(encoding=None)
-    assert len(contents) == 0
+        with pytest.raises(ValueError):
+            sequence.filter(test_sequence_set, f"http://thisismocked.com/{sequence_file}", tmpdir)
 
 
 def test_filter_empty_fasta_xz(tmpdir):


### PR DESCRIPTION
Closes #82 

**Background**

TL;DR: try to improve the performance of filtering the sequence file prior to clade assignment
The ticket linked above has more details, as well as a reference to the corresponding RFC.

**Testing**

- The PR contains an additional test for end-to-end clade assignment (though admittedly the test data could be more...robust).
- There's a branch on variant-nowcast-hub that generates target data using this branch of Cladetime. A manual run of the `Run post-submission jobs` against that branch generated target data _and_  did not create a pull request because the target data files match those that created against the main branch earlier this week. Output from that run: https://github.com/reichlab/variant-nowcast-hub/actions/runs/12837193998/job/35800364997

**Timing**

The above GitHub action run with biobear reduced the time it takes to filter the sequence file by about 35%. However, the overall run time of `create-target-data` reduced about 12%. Of course, these statistics are from a single run.

[Specs for the standard runner](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) are 4 processors, 16 GB memory, and 14 GB storage. This explains why the GitHub actions run didn't yield the performance gains that I saw locally.
The bottleneck now appears to be clade assignment itself.