### PR TITLE
Pin third-party GitHub actions by commit hash and add explicit workflow permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 
 env:
   FORCE_COLOR: "1"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
           cache: pip
 
       - name: Install uv 🌟
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@1edb52594c857e2b5b13128931090f0640537287 # v5.3.0
         with:
           version: ">=0.0.1"
 

--- a/.github/workflows/publish-pypi-test.yaml
+++ b/.github/workflows/publish-pypi-test.yaml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/publish-pypi-test.yaml
+++ b/.github/workflows/publish-pypi-test.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-python@v5
 
       - name: Install uv 🌟
-        uses: astral-sh/setup-uv@887a942a15af3a7626099df99e897a18d9e5ab3a # v5.1.0
+        uses: astral-sh/setup-uv@1edb52594c857e2b5b13128931090f0640537287 # v5.3.0
 
       - name: Build package for distribution 🛠️
         run: |
@@ -54,6 +54,6 @@ jobs:
         name: cladetime-package-distribution
         path: dist/
     - name: Publish distribution to TestPyPI 🚀
-      uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # v1.1.12
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -58,7 +58,7 @@ jobs:
         name: cladetime-package-distribution
         path: dist/
     - name: Publish distribution to PyPI 🚀
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
 
   github-release:
     name: >-
@@ -79,7 +79,7 @@ jobs:
         name: cladetime-package-distribution
         path: dist/
     - name: Sign the dists with Sigstore 📝
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 # v3.0.0
       with:
         inputs: >-
           ./dist/*.tar.gz

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -9,6 +9,8 @@ on:
     tags:
       # only run workflow for tags in release format
       - "v[0-9]+.[0-9]+.[0-9]+"
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Closes #90 

Yesterday's PR closed most of our outstanding security alerts, and this one should close out the rest.

The changes:
- pin third-party actions using commit hashes instead of tags.
- make sure each workflow has explicit GITHUB_TOKEN permissions

----------


Unrelated but interesting: the [CODEOWNERS file merged yesterday](https://github.com/reichlab/cladetime/blob/main/.github/CODEOWNERS) is doing its thing! (it specifies that at least one reviewer from the code-owner team has to approve workflow updates):

![image](https://github.com/user-attachments/assets/7ae24f0e-7fae-44ea-a756-d8c09a742633)
