### PR TITLE
Align Cladetime documentation with Python release process in the Hubverse Developer Guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to Cladetime are documented here. Cladetime uses
+[Semantic Versioning](https://semver.org/).
+
+## [unreleased]
+
+## 0.3.0
+
+### Changed
+
+- Performance improvement: use [biobear](https://github.com/wheretrue/biobear) as .fasta file reader for
+  ZSTD-compressed sequence data
+- `sequence_as_of` and `tree_as_of` timestamps now default to 23:59:59 UTC instead of 00:00:00 UTC
+
+## 0.2.4
+
+### Added
+
+- Publish Cladetime to PyPI
+
+### Changed
+
+- Make the Clade class public
+
+## 0.2.3
+
+### Added
+
+- [Contributing guidelines](CONTRIBUTING.md)
+- [Cladetime package documentation](https://cladetime.readthedocs.io/)
+- Support for demo mode that uses Nextstrain's 100k sample instead of an entire SARS-CoV-2 sequence dataset
+- New `CladeTime.assign_clades` method that assigns clades to SARS-CoV-2 sequences using a point-in-time reference tree
+- New `nextclade_dataset_name` attribute in `CladeTime.ncov_metadata`
+- Warning message when Docker is not detected during Cladetime initialization
+
+### Changed
+
+- Package renamed to `cladetime`
+
+### Fixed
+
+- Output clade assignments as .tsv instead of .csv
+- Fix UTC timezone bug when setting `CladeTime.sequence_as_of` and `CladeTime.tree_as_of`
+
+### Removed
+
+- Cladetime CLI removed in favor of programmatic usage
+- The `get_clade_list.py` functionality has moved to the
+  [`variant-nowcast-hub`](https://github.com/reichlab/variant-nowcast-hub/blob/main/src/get_clades_to_model.py)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,13 +69,11 @@ test suite. If the tests pass, you're ready to start developing on Cladetime!
 
 ### Making and submitting changes
 
-To get started, create a new branch for your changes. The branch name should
-use the format
-`<your initials>/<change-name>/<issue-number-if-applicable>`.
+Cladetime follows the Hubverse Python development process.
 
-After you've created a new branch, make and test your changes.
-We recommend making incremental changes and small commits so it's
-easier for code reviewers to understand the updates.
+Once you have the project set up on your machine, follow the
+[development checklist in the Hubverse Developer Guide](https://hubverse.io/en/latest/developer/python.html#checklists)
+to update the code and submit a pull request.
 
 Cladetime uses the following guidelines and tools to maintain code quality.
 If you want to contribute but have questions about these tools, free to ask
@@ -94,17 +92,6 @@ and new features should be accompanied by new tests.
 If you're adding or updating features that impact the documentation, please
 include those updates with your changes (see below for more information about
 updating Cladetime's documentation).
-
-When your changes are complete and you're ready to submit a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests),
-follow these steps:
-
-1. If the repository has a CHANGELOG.md file, update it with a description of
-your changes.
-2. Push the changes to your forked repository.
-3. From your forked repository on GitHub, create a pull request for your branch, targeting
-the `main` branch of the original `cladetime` repository.
-
-4. A team member will review the pull request and be in touch.
 
 ### Adding new dependencies
 
@@ -174,3 +161,8 @@ adding a new project dependency as described above:
     ```bash
     uv pip install -r requirements/requirements-docs.txt
     ```
+
+## Release a new version of Cladetime
+
+If you're a Cladetime maintainer and want to create a new release, follow the
+[Python release checklist in the Hubverse Developer Guide](https://hubverse.io/en/latest/developer/python.html#release-checklist).


### PR DESCRIPTION
Closes #94 

This PR:

- Adds a CHANGELOG to Cladetime
- Updates CONTRIBUTING.md to reference the Hubverse Python dev docs instead of maintaining its own copy