### PR TITLE
Fixups to the Python dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,22 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+        # group all run-of-the mill updates into a single pull request
+    groups:
+      gha-updates:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor
 
   - package-ecosystem: "pip"
-    directory: "/requirements/"
+    directory: "/"
     schedule:
       interval: "weekly"
+    # group all run-of-the mill updates into a single pull request
+    groups:
+      py-updates:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor


### PR DESCRIPTION
1. Group patch and minor updates into a single PR
2. Change the directory from /requirements/ to / because we want updates to be driven by pyproject.toml, not by our lockfiles