### PR TITLE
Update cladetime metadata in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,17 @@ name = "cladetime"
 dynamic = ["version"]
 description = "Assign clades to SARS-CoV-2 genome sequences at a point in time."
 authors = [
-    {name = "Reich Lab @ University of Massachusetts", email = "nick@umass.edu"},
-]
-maintainers = [
-    {name = "Becky Sweger", email = "rsweger@umass.edu"},
+    {name = "Becky Sweger", email = "bsweger@gmail.com"},
     {name = "Evan Ray", email="elray@umass.edu"},
     {name = "Ben Rogers", email = "bwrogers@umass.edu"},
 ]
+
+maintainers = [
+    {name = "Zhian Kamvar", email = "zkamvar@umass.edu"},
+    {name = "Mattew Cornell", email = "cornell@schoolph.umass.edu"},
+    {name = "Nick Reich", email = "nick@umass.edu"},
+]
+
 license = {text = "MIT License"}
 keywords = ["biostatistics", "clade", "covid", "epidemiology", "genome", "sequence"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Assign clades to SARS-CoV-2 genome sequences at a point in time."
 authors = [
     {name = "Becky Sweger", email = "bsweger@gmail.com"},
     {name = "Evan Ray", email="elray@umass.edu"},
-    {name = "Ben Rogers", email = "bwrogers@umass.edu"},
+    {name = "Ben Rogers", email = "benwrogers87@gmail.com"},
 ]
 
 maintainers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,11 @@ maintainers = [
     {name = "Nick Reich", email = "nick@umass.edu"},
 ]
 
-license = {text = "MIT License"}
+license = "MIT"
 keywords = ["biostatistics", "clade", "covid", "epidemiology", "genome", "sequence"]
 
 classifiers = [
   "Development Status :: 4 - Beta",
-  "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
@@ -119,4 +118,3 @@ ignore_missing_imports = false
 # ensure setuptools_scm generates a version number that reflects latest tags
 # https://docs.astral.sh/uv/concepts/cache/#dynamic-metadata
 cache-keys = [{ git = { commit = true, tags = true } }]
-


### PR DESCRIPTION
This PR includes two small changes to Cladetime's metadata in `pyproject.toml` that can be reviewed commit by commit.

I've already spoken to @nickreich about the author updates, and he is 👍 
