### PR TITLE
Change Dependabot versioning strategy to "widen"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: "widen"
     # group all run-of-the mill updates into a single pull request
     groups:
       py-updates:


### PR DESCRIPTION
This is another attempt to ensure that Dependabot submits PRs with resolvable dependencies. The "widen" versioning strategy includes both the old and new version of packages.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versioning-strategy--