### PR TITLE
Update Dependabot configuration again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,3 @@ updates:
     groups:
       py-updates:
         applies-to: version-updates
-        update-types:
-          - patch
-          - minor


### PR DESCRIPTION
Dependabot continues to create PRs for major releases that are not compatible with verison upgrades for minor release. This changeset is an experiment to see if we can improve this situation including the major release in grouped PRs instead of doing them individually.