### PR TITLE
Add ruleset to py-updates dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
     groups:
       py-updates:
         applies-to: version-updates
+        update-types:
+          - patch
+          - minor
+          - major


### PR DESCRIPTION
The prior commit omitted `update-types` from the py-updates Dependabot grouping entirely (because we want grouped PRs to include everything)

However, that resulting in a config error (I'm guessing because there needs to be at least one ruleset for Dependabot to use when creating the group).

So let's try another way!